### PR TITLE
The gsl error catcher

### DIFF
--- a/cjam/_jam_axi.pyx
+++ b/cjam/_jam_axi.pyx
@@ -26,6 +26,7 @@ def axi_vel(xp, yp, incl, lum_area, lum_sigma, lum_q, pot_area, pot_sigma, pot_q
     cdef double [:] c_vx
     cdef double [:] c_vy
     cdef double [:] c_vz
+    cdef int c_gslFlag_vel = 0
     
     # set C arrays to be views into the input arrays
     c_xp = np.array(xp, dtype=np.double, copy=False)
@@ -52,12 +53,12 @@ def axi_vel(xp, yp, incl, lum_area, lum_sigma, lum_q, pot_area, pot_sigma, pot_q
         cython_jam.jam_axi_vel(&c_xp[0], &c_yp[0], nxy, incl,
             &c_lum_area[0], &c_lum_sigma[0], &c_lum_q[0], lum_total,
             &c_pot_area[0], &c_pot_sigma[0], &c_pot_q[0], pot_total,
-            &c_beta[0], &c_kappa[0], nrad, nang, &c_vx[0], &c_vy[0], &c_vz[0])
+            &c_beta[0], &c_kappa[0], nrad, nang, &c_vx[0], &c_vy[0], &c_vz[0], &c_gslFlag_vel)
     except:
         print("CJAM first moments failed in axi_vel.")
         return False
     
-    return vx, vy, vz
+    return vx, vy, vz, c_gslFlag_vel
 
 
 
@@ -152,7 +153,7 @@ def axisymmetric(xp, yp, tracer_mge, potential_mge, distance, beta=0, kappa=0, n
     
     # calculate first moments
     try:
-        vx, vy, vz = axi_vel(\
+        vx, vy, vz, gslFlag_vel = axi_vel(\
             (xp*distance/u.rad).to("pc").value,
             (yp*distance/u.rad).to("pc").value,
             incl.to("rad").value,
@@ -166,8 +167,12 @@ def axisymmetric(xp, yp, tracer_mge, potential_mge, distance, beta=0, kappa=0, n
             kappa,
             nrad,
             nang)
+        
     except:
         print("CJAM first moments failed in axisymmetric.")
+        return False
+    
+    if (gslFlag_vel > 0): # gsl roundoff error occured. The model is not good
         return False
     
     # calculate second moments
@@ -185,14 +190,13 @@ def axisymmetric(xp, yp, tracer_mge, potential_mge, distance, beta=0, kappa=0, n
             beta,
             nrad,
             nang)
-        print("In jam_pyx: {}".format(gslFlag_rms))
+        
     except:
         print("CJAM second moments failed in axisymmetric.")
         return False
     
-    if (gslFlag_rms > 0):
-	#print("gsl roundoff error occured. The model is not good") # Tadeja was here
-        return False # Tadeja was here
+    if (gslFlag_rms > 0): # gsl roundoff error occured. The model is not good
+        return False
    
     # put results into astropy table, also convert PMs to mas/yr
     kms2masyr = (u.km/u.s*u.rad/distance).to("mas/yr")

--- a/cjam/_jam_axi.pyx
+++ b/cjam/_jam_axi.pyx
@@ -188,6 +188,11 @@ def axisymmetric(xp, yp, tracer_mge, potential_mge, distance, beta=0, kappa=0, n
         print("CJAM second moments failed in axisymmetric.")
         return False
     
+    if (np.sum(rxx)==0.) & (np.sum(ryy)==0.) & (np.sum(rzz)==0.) &\
+       	(np.sum(rxy)==0.) & (np.sum(rxz)==0.) & (np.sum(ryz)==0.): # Tadeja was here
+       	#print("gsl roundoff error occured. The model is not good") # Tadeja was here
+        return False # Tadeja was here
+   
     # put results into astropy table, also convert PMs to mas/yr
     kms2masyr = (u.km/u.s*u.rad/distance).to("mas/yr")
     moments = table.QTable()

--- a/cython_jam.pxd
+++ b/cython_jam.pxd
@@ -12,4 +12,4 @@ cdef extern from "../src/jam/jam.h":
         double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
         double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
         double *beta, double *kappa, int nrad, int nang, double *vx, \
-        double *vy, double *vz)
+        double *vy, double *vz, int *gslFlag_vel)

--- a/cython_jam.pxd
+++ b/cython_jam.pxd
@@ -6,7 +6,7 @@ cdef extern from "../src/jam/jam.h":
         double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
         double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
         double *beta, int nrad, int nang, double *rxx, double *ryy, \
-        double *rzz, double *rxy, double *rxz, double *ryz)
+        double *rzz, double *rxy, double *rxz, double *ryz, int *gslFlag_rms)
     
     void jam_axi_vel(double *xp, double *yp, int nxy, double incl, \
         double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \

--- a/src/jam/jam.h
+++ b/src/jam/jam.h
@@ -72,10 +72,10 @@ double jam_axi_rms_mgeint( double, void * );
 
 double* jam_axi_rms_mmt( double *,double *, int, double, \
     struct multigaussexp *, struct multigaussexp *, double *, \
-    int, int, int );
+    int, int, int , int *);
 
 double* jam_axi_rms_wmmt( double *, double *, int, double, \
-    struct multigaussexp *, struct multigaussexp *, double *, int );
+    struct multigaussexp *, struct multigaussexp *, double *, int , int *);
 
 void jam_axi_vel(double *xp, double *yp, int nxy, double incl, \
     double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \

--- a/src/jam/jam.h
+++ b/src/jam/jam.h
@@ -82,7 +82,7 @@ void jam_axi_vel(double *xp, double *yp, int nxy, double incl, \
     double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
     double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
     double *beta, double *kappa, int nrad, int nang, double *vx, double *vy, \
-    double *vz);
+    double *vz, int *gslFlag_vel);
 
 double jam_axi_vel_losint( double, void * );
 
@@ -90,7 +90,7 @@ double jam_axi_vel_mgeint( double, void * );
 
 struct jam_vel jam_axi_vel_mmt( double *, double *, int, double, \
     struct multigaussexp *, struct multigaussexp *, double *, double *, \
-    int, int );
+    int, int , int *);
 
 double** jam_axi_vel_wmmt( double *, double *, int, double, \
-    struct multigaussexp *, struct multigaussexp *, double *, double * );
+    struct multigaussexp *, struct multigaussexp *, double *, double *, int * );

--- a/src/jam/jam.h
+++ b/src/jam/jam.h
@@ -42,6 +42,7 @@ struct params_losint {
     struct multigaussexp *lum, *pot;
     double xp, yp, incl, *bani, *s2l, *q2l, *s2q2l, *s2p, *e2p, *kappa;
     double zpow;
+    int *gslFlag_losint;
 };
 
 struct params_mgeint {
@@ -66,7 +67,7 @@ void jam_axi_rms(double *xp, double *yp, int nxy, double incl, \
     double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
     double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
     double *beta, int nrad, int nang, double *rxx, double *ryy, double *rzz, \
-    double *rxy, double *rxz, double *ryz);
+    double *rxy, double *rxz, double *ryz, int *gslFlag_rms);
 
 double jam_axi_rms_mgeint( double, void * );
 

--- a/src/jam/jam_axi_rms.c
+++ b/src/jam/jam_axi_rms.c
@@ -86,7 +86,7 @@ double *rxy, double *rxz, double *ryz, int *gslFlag_rms) {
     }
     //printf("rms.c %d\n", *gslFlag);
     if (*gslFlag > 0) {
-       	printf("\nCJAM error: gsl round off occured in calculation of 2nd moments, returning False\n");
+       	printf("\nCJAM error: gsl round off occurred in the calculation of 2nd moments, returning False.\n");
 	}
     *gslFlag_rms += *gslFlag;
     //printf("rms.c %d\n", *gslFlag_rms);

--- a/src/jam/jam_axi_rms.c
+++ b/src/jam/jam_axi_rms.c
@@ -40,8 +40,8 @@ double *rxy, double *rxz, double *ryz) {
     
     struct multigaussexp lum, pot;
     double* mu;
-    int i, check;
-    
+    int i, check, *gslFlag;
+    int GSLVar = 0; gslFlag = &GSLVar;
     // put luminous MGE components into structure
     lum.area = lum_area;
     lum.sigma = lum_sigma;
@@ -55,7 +55,7 @@ double *rxy, double *rxz, double *ryz) {
     pot.ntotal = pot_total;
     
     // calculate xx moments and put into results array
-    mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 1);
+    mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 1, gslFlag);
     for (i=0; i<nxy; i++) rxx[i] = mu[i];
     
     // check for any non-zero beta or non-unity flattening
@@ -66,15 +66,15 @@ double *rxy, double *rxz, double *ryz) {
     
     // for anisotropic models, calculate the 
     if (check>0) {
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 2);
+        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 2, gslFlag);
         for (i=0; i<nxy; i++) ryy[i] = mu[i];
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 3);
+        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 3, gslFlag);
         for (i=0; i<nxy; i++) rzz[i] = mu[i];
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 4);
+        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 4, gslFlag);
         for (i=0; i<nxy; i++) rxy[i] = mu[i];
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 5);
+        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 5, gslFlag);
         for (i=0; i<nxy; i++) rxz[i] = mu[i];
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 6);
+        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 6, gslFlag);
         for (i=0; i<nxy; i++) ryz[i] = mu[i];
     }
     else {
@@ -85,6 +85,16 @@ double *rxy, double *rxz, double *ryz) {
         for (i=0; i<nxy; i++) ryz[i] = 0.;
     }
     
+    if (*gslFlag > 0) {
+       	printf("\nCJAM error: gsl round off occured in calculation of 2nd moments. Setting all second momments to 0\n");
+	for (i=0; i<nxy; i++) rxx[i] = 0.;
+       	for (i=0; i<nxy; i++) ryy[i] = 0.;
+       	for (i=0; i<nxy; i++) rzz[i] = 0.;
+       	for (i=0; i<nxy; i++) rxy[i] = 0.;
+       	for (i=0; i<nxy; i++) rxz[i] = 0.;
+       	for (i=0; i<nxy; i++) ryz[i] = 0.;
+    }
+
     // free memory
     free(mu);
     

--- a/src/jam/jam_axi_rms.c
+++ b/src/jam/jam_axi_rms.c
@@ -36,7 +36,7 @@ void jam_axi_rms(double *xp, double *yp, int nxy, double incl, \
 double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
 double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
 double *beta, int nrad, int nang, double *rxx, double *ryy, double *rzz,
-double *rxy, double *rxz, double *ryz) {
+double *rxy, double *rxz, double *ryz, int *gslFlag_rms) {
     
     struct multigaussexp lum, pot;
     double* mu;
@@ -84,18 +84,14 @@ double *rxy, double *rxz, double *ryz) {
         for (i=0; i<nxy; i++) rxz[i] = 0.;
         for (i=0; i<nxy; i++) ryz[i] = 0.;
     }
-    
+    //printf("rms.c %d\n", *gslFlag);
     if (*gslFlag > 0) {
-       	printf("\nCJAM error: gsl round off occured in calculation of 2nd moments. Setting all second momments to 0\n");
-	for (i=0; i<nxy; i++) rxx[i] = 0.;
-       	for (i=0; i<nxy; i++) ryy[i] = 0.;
-       	for (i=0; i<nxy; i++) rzz[i] = 0.;
-       	for (i=0; i<nxy; i++) rxy[i] = 0.;
-       	for (i=0; i<nxy; i++) rxz[i] = 0.;
-       	for (i=0; i<nxy; i++) ryz[i] = 0.;
-    }
+       	printf("\nCJAM error: gsl round off occured in calculation of 2nd moments, returning False\n");
+	}
+    *gslFlag_rms += *gslFlag;
+    //printf("rms.c %d\n", *gslFlag_rms);
+    
 
-    // free memory
     free(mu);
     
     return;

--- a/src/jam/jam_axi_rms_mmt.c
+++ b/src/jam/jam_axi_rms_mmt.c
@@ -40,7 +40,7 @@
 
 double* jam_axi_rms_mmt( double *xp, double *yp, int nxy, double incl, \
         struct multigaussexp *lum, struct multigaussexp *pot, double *beta, \
-        int nrad, int nang, int vv ) {
+        int nrad, int nang, int vv , int *gslFlag) {
     
     int i, j, k, npol;
     double qmed, *rell, *r, *e, step, rmax, *lograd, *rad, *ang, *angvec;
@@ -51,7 +51,7 @@ double* jam_axi_rms_mmt( double *xp, double *yp, int nxy, double incl, \
     if ( nrad * nang > nxy ) {
         
         // weighted second moment
-        wm2 = jam_axi_rms_wmmt( xp, yp, nxy, incl, lum, pot, beta, vv );
+        wm2 = jam_axi_rms_wmmt( xp, yp, nxy, incl, lum, pot, beta, vv, gslFlag);
         
         if ( vv == 4 ) {
             for ( i = 0; i < nxy; i++ ) {
@@ -126,7 +126,7 @@ double* jam_axi_rms_mmt( double *xp, double *yp, int nxy, double incl, \
     
     
     // weighted second moment on polar grid
-    wm2 = jam_axi_rms_wmmt( xpol, ypol, npol, incl, lum, pot, beta, vv );
+    wm2 = jam_axi_rms_wmmt( xpol, ypol, npol, incl, lum, pot, beta, vv, gslFlag );
     
     // surface brightness on polar grid
     surf = mge_surf( lum, xpol, ypol, npol );

--- a/src/jam/jam_axi_rms_mmt.c
+++ b/src/jam/jam_axi_rms_mmt.c
@@ -187,7 +187,6 @@ double* jam_axi_rms_mmt( double *xp, double *yp, int nxy, double incl, \
     free( surf );
     free( r );
     free( e );
-    printf("rms_mmt.c %d\n", *gslFlag_rms);
     
     return mu;
     

--- a/src/jam/jam_axi_rms_mmt.c
+++ b/src/jam/jam_axi_rms_mmt.c
@@ -40,7 +40,7 @@
 
 double* jam_axi_rms_mmt( double *xp, double *yp, int nxy, double incl, \
         struct multigaussexp *lum, struct multigaussexp *pot, double *beta, \
-        int nrad, int nang, int vv , int *gslFlag) {
+        int nrad, int nang, int vv , int *gslFlag_rms) {
     
     int i, j, k, npol;
     double qmed, *rell, *r, *e, step, rmax, *lograd, *rad, *ang, *angvec;
@@ -51,7 +51,7 @@ double* jam_axi_rms_mmt( double *xp, double *yp, int nxy, double incl, \
     if ( nrad * nang > nxy ) {
         
         // weighted second moment
-        wm2 = jam_axi_rms_wmmt( xp, yp, nxy, incl, lum, pot, beta, vv, gslFlag);
+        wm2 = jam_axi_rms_wmmt( xp, yp, nxy, incl, lum, pot, beta, vv, gslFlag_rms);
         
         if ( vv == 4 ) {
             for ( i = 0; i < nxy; i++ ) {
@@ -126,7 +126,7 @@ double* jam_axi_rms_mmt( double *xp, double *yp, int nxy, double incl, \
     
     
     // weighted second moment on polar grid
-    wm2 = jam_axi_rms_wmmt( xpol, ypol, npol, incl, lum, pot, beta, vv, gslFlag );
+    wm2 = jam_axi_rms_wmmt( xpol, ypol, npol, incl, lum, pot, beta, vv, gslFlag_rms );
     
     // surface brightness on polar grid
     surf = mge_surf( lum, xpol, ypol, npol );
@@ -187,6 +187,7 @@ double* jam_axi_rms_mmt( double *xp, double *yp, int nxy, double incl, \
     free( surf );
     free( r );
     free( e );
+    printf("rms_mmt.c %d\n", *gslFlag_rms);
     
     return mu;
     

--- a/src/jam/jam_axi_rms_wmmt.c
+++ b/src/jam/jam_axi_rms_wmmt.c
@@ -39,7 +39,7 @@
 
 double *jam_axi_rms_wmmt( double *xp, double *yp, int nxy, double incl, \
         struct multigaussexp *lum, struct multigaussexp *pot, \
-        double *beta, int vv , int *gslFlag) {
+        double *beta, int vv , int *gslFlag_rms) {
     
     struct params_rmsint p;
     struct multigaussexp ilum, ipot;
@@ -115,7 +115,9 @@ double *jam_axi_rms_wmmt( double *xp, double *yp, int nxy, double incl, \
     int test = 1;
     status += test; 
     */
-    if (status > 0) { *gslFlag += 1;   }    
+    printf("status: %d\n", status);
+    if (status > 0) { *gslFlag_rms += 1;   }    
+    printf("rms_wmmt.c %d\n", *gslFlag_rms);
 
 
     gsl_integration_workspace_free( w );

--- a/src/jam/jam_axi_rms_wmmt.c
+++ b/src/jam/jam_axi_rms_wmmt.c
@@ -115,9 +115,7 @@ double *jam_axi_rms_wmmt( double *xp, double *yp, int nxy, double incl, \
     int test = 1;
     status += test; 
     */
-    printf("status: %d\n", status);
-    if (status > 0) { *gslFlag_rms += 1;   }    
-    printf("rms_wmmt.c %d\n", *gslFlag_rms);
+    if (status > 0) { *gslFlag_rms += 1;   }
 
 
     gsl_integration_workspace_free( w );

--- a/src/jam/jam_axi_rms_wmmt.c
+++ b/src/jam/jam_axi_rms_wmmt.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <gsl/gsl_integration.h>
+#include <gsl/gsl_errno.h>
 #include "jam.h"
 #include "../mge/mge.h"
 #include "../tools/tools.h"
@@ -38,13 +39,14 @@
 
 double *jam_axi_rms_wmmt( double *xp, double *yp, int nxy, double incl, \
         struct multigaussexp *lum, struct multigaussexp *pot, \
-        double *beta, int vv ) {
+        double *beta, int vv , int *gslFlag) {
     
     struct params_rmsint p;
     struct multigaussexp ilum, ipot;
     double ci, si, *kani, *s2l, *q2l, *s2q2l, *s2p, *e2p;
     double result, error, *sb_mu2;
     int i;
+    int status = 0;
     
     // convert from projected MGEs to intrinsic MGEs
     ilum = mge_deproject( lum, incl );
@@ -95,6 +97,7 @@ double *jam_axi_rms_wmmt( double *xp, double *yp, int nxy, double incl, \
     
     gsl_integration_workspace *w = gsl_integration_workspace_alloc( 1000 );
     gsl_function F;
+    gsl_set_error_handler_off();
     F.function = &jam_axi_rms_mgeint;
     
     sb_mu2 = (double *) malloc( nxy * sizeof( double ) );
@@ -103,11 +106,18 @@ double *jam_axi_rms_wmmt( double *xp, double *yp, int nxy, double incl, \
         p.y2 = yp[i] * yp[i];
         p.xy = xp[i] * yp[i];
         F.params = &p;
-        gsl_integration_qag( &F, 0., 1., 0., 1e-5, 1000, 6, w, \
+        status += gsl_integration_qag( &F, 0., 1., 0., 1e-5, 1000, 6, w, \
             &result, &error );
         sb_mu2[i] = result;
     }
-    
+
+    /*// if you want to test the gsl flagging thing uncomment these two lines
+    int test = 1;
+    status += test; 
+    */
+    if (status > 0) { *gslFlag += 1;   }    
+
+
     gsl_integration_workspace_free( w );
     
     free( kani );

--- a/src/jam/jam_axi_vel.c
+++ b/src/jam/jam_axi_vel.c
@@ -34,11 +34,12 @@ void jam_axi_vel(double *xp, double *yp, int nxy, double incl, \
 double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
 double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
 double *beta, double *kappa, int nrad, int nang, double *vx, double *vy, \
-double *vz) {
+double *vz, int *gslFlag_vel) {
     
     struct multigaussexp lum, pot;
     struct jam_vel vm;
-    int i, j, k, check;
+    int i, j, k, check, *gslFlag;
+    int GSLVar = 0; gslFlag = &GSLVar;
     
     // put luminous MGE components into structure
     lum.area = lum_area;
@@ -61,7 +62,7 @@ double *vz) {
     if (check>0) {
         // calculate moments and put into results arrays
         vm = jam_axi_vel_mmt(xp, yp, nxy, incl, &lum, &pot, beta, kappa,
-            nrad, nang);
+            nrad, nang, gslFlag);
         for (i=0; i<nxy; i++) {
             vx[i] = vm.vx[i];
             vy[i] = vm.vy[i];
@@ -80,6 +81,10 @@ double *vz) {
             vz[i] = 0.;
         }
     }
+    if (*gslFlag > 0) {
+       	printf("\nCJAM error: gsl round off occured in calculation of 1st moments, returning False\n");
+	}
+    *gslFlag_vel += *gslFlag;
     
     return;
 }

--- a/src/jam/jam_axi_vel.c
+++ b/src/jam/jam_axi_vel.c
@@ -82,7 +82,7 @@ double *vz, int *gslFlag_vel) {
         }
     }
     if (*gslFlag > 0) {
-       	printf("\nCJAM error: gsl round off occured in calculation of 1st moments, returning False\n");
+       	printf("\nCJAM error: gsl round off occurred in calculation of the 1st moments, returning False.\n");
 	}
     *gslFlag_vel += *gslFlag;
     

--- a/src/jam/jam_axi_vel_losint.c
+++ b/src/jam/jam_axi_vel_losint.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <gsl/gsl_integration.h>
+#include <gsl/gsl_errno.h>
 #include "jam.h"
 #include "../mge/mge.h"
 
@@ -35,6 +36,7 @@ double jam_axi_vel_losint(double zp, void *params) {
     double xp, yp, si, ci, r, z, r2, z2, nu, intg, result, error, nu_i;
     double sign_kappa, sum;
     int i;
+    int status = 0;//, bla; // Tadeja was here
     
     // get parameters
     lp = params;
@@ -62,7 +64,7 @@ double jam_axi_vel_losint(double zp, void *params) {
     gsl_integration_workspace *w = gsl_integration_workspace_alloc(1000);
     gsl_function F;
     F.function = &jam_axi_vel_mgeint;
-    
+    gsl_set_error_handler_off(); //Tadeja was here
     sum = 0.;
     for (i=0; i<lp->lum->ntotal; i++) {
         if (lp->kappa[i]==0.) sign_kappa = 0.;
@@ -74,7 +76,7 @@ double jam_axi_vel_losint(double zp, void *params) {
         mp.q2l = lp->q2l[i];
         mp.s2q2l = lp->s2q2l[i];
         F.params = &mp;
-        gsl_integration_qag(&F, 0., 1., 0., 1e-5, 1000, 6, w, &result, &error);
+        status += gsl_integration_qag(&F, 0., 1., 0., 1e-5, 1000, 6, w, &result, &error);
         sum += sign_kappa * pow(lp->kappa[i], 2) * nu_i * fabs(result);
     }
     
@@ -88,6 +90,18 @@ double jam_axi_vel_losint(double zp, void *params) {
     
     intg *= pow(zp, lp->zpow);
     
+    // if you want to test the gsl flagging thing uncomment these two lines
+    int test = 1;// Tadeja
+    status += test; // Tadeja
+    //bla = *lp->gslFlag_losint;
+    //printf("bla: %i, gsl flag: %d\n", bla,  *lp->gslFlag_losint);
+    if (status > 0 && *lp->gslFlag_losint<=10) { // the limiting value is very arbitrary
+        //printf("losint gsl fail\n"); // Tadeja
+        *lp->gslFlag_losint += 1;   }// Tadeja
+
+    if (status > 0 && *lp->gslFlag_losint>10) { // the limiting value is very arbitrary
+        //printf("losint gsl fail\n");// Tadeja
+        *lp->gslFlag_losint -= 1;   }// Tadeja
     return intg;
     
 }

--- a/src/jam/jam_axi_vel_losint.c
+++ b/src/jam/jam_axi_vel_losint.c
@@ -36,7 +36,7 @@ double jam_axi_vel_losint(double zp, void *params) {
     double xp, yp, si, ci, r, z, r2, z2, nu, intg, result, error, nu_i;
     double sign_kappa, sum;
     int i;
-    int status = 0;//, bla; // Tadeja was here
+    int status = 0;
     
     // get parameters
     lp = params;
@@ -64,7 +64,7 @@ double jam_axi_vel_losint(double zp, void *params) {
     gsl_integration_workspace *w = gsl_integration_workspace_alloc(1000);
     gsl_function F;
     F.function = &jam_axi_vel_mgeint;
-    gsl_set_error_handler_off(); //Tadeja was here
+    gsl_set_error_handler_off(); 
     sum = 0.;
     for (i=0; i<lp->lum->ntotal; i++) {
         if (lp->kappa[i]==0.) sign_kappa = 0.;
@@ -90,18 +90,15 @@ double jam_axi_vel_losint(double zp, void *params) {
     
     intg *= pow(zp, lp->zpow);
     
-    // if you want to test the gsl flagging thing uncomment these two lines
+    /*// if you want to test the gsl flagging thing uncomment these two lines
     int test = 1;// Tadeja
     status += test; // Tadeja
-    //bla = *lp->gslFlag_losint;
-    //printf("bla: %i, gsl flag: %d\n", bla,  *lp->gslFlag_losint);
-    if (status > 0 && *lp->gslFlag_losint<=10) { // the limiting value is very arbitrary
-        //printf("losint gsl fail\n"); // Tadeja
-        *lp->gslFlag_losint += 1;   }// Tadeja
+    */
+    if (status > 0 && *lp->gslFlag_losint<=10) { // the limiting value is very arbitrary so that the values do not exceed allowed size for integers
+        *lp->gslFlag_losint += 1;   }
 
-    if (status > 0 && *lp->gslFlag_losint>10) { // the limiting value is very arbitrary
-        //printf("losint gsl fail\n");// Tadeja
-        *lp->gslFlag_losint -= 1;   }// Tadeja
+    if (status > 0 && *lp->gslFlag_losint>10) { // the limiting value is very arbitrary so that the values do not exceed allowed size for integers
+        *lp->gslFlag_losint -= 1;   }
     return intg;
     
 }

--- a/src/jam/jam_axi_vel_mmt.c
+++ b/src/jam/jam_axi_vel_mmt.c
@@ -39,7 +39,7 @@
 
 struct jam_vel jam_axi_vel_mmt( double *xp, double *yp, int nxy, \
         double incl, struct multigaussexp *lum, struct multigaussexp *pot, \
-        double *beta, double *kappa, int nrad, int nang ) {
+        double *beta, double *kappa, int nrad, int nang, int *gslFlag_vel ) {
     
     int i, j, k, v, npol;
     double qmed, *rell, *r, *e, step, rmax, *lograd, *rad, *ang, *angvec;
@@ -55,7 +55,7 @@ struct jam_vel jam_axi_vel_mmt( double *xp, double *yp, int nxy, \
     if ( nrad * nang > nxy ) {
         
         // weighted first moments
-        wm1 = jam_axi_vel_wmmt( xp, yp, nxy, incl, lum, pot, beta, kappa );
+        wm1 = jam_axi_vel_wmmt( xp, yp, nxy, incl, lum, pot, beta, kappa, gslFlag_vel );
         
         // surface brightness
         surf = mge_surf( lum, xp, yp, nxy );
@@ -127,7 +127,7 @@ struct jam_vel jam_axi_vel_mmt( double *xp, double *yp, int nxy, \
     }
     
     // weighted first moments on polar grid
-    wm1 = jam_axi_vel_wmmt( xpol, ypol, npol, incl, lum, pot, beta, kappa );
+    wm1 = jam_axi_vel_wmmt( xpol, ypol, npol, incl, lum, pot, beta, kappa, gslFlag_vel );
     
     // surface brightness on polar grid
     surf = mge_surf( lum, xpol, ypol, npol );


### PR DESCRIPTION
For specific parameters a round-off error occurs in the integration with the function _gsl_integration_qag(...)_. The error in most cases is not reproducible and is somewhat randomly dependent on hardware and software. It is also very rare (<0.01% in my tests) therefore, we consider that is it not relevant what is the exact nature of the error. The catcher thus only propagates the failure in the integration and not the exact flag.

(If you want to know the exact status of the error (as described in the **gsl_errno.h**) you can toggle the printout of the status  flag in each of the three instances of _status += gsl_integration_qag(...)_ in the cjam code.)

The fix separably propagates the gsl error flags (_gslFlag*_) from the 1st and the 2nd moments to the **_jam_axi.pyx**.  Where 0 means no error occurred and >0 indicates a failure in integration.
If either occur the output of cjam is False! For troubleshooting purposes this is kept separate from other errors and error is reported within the c code:

    CJAM error: gsl round off occurred in calculation of 2nd moments, returning False
    CJAM error: gsl round off occurred in calculation of 1st moments, returning False
