### PR TITLE
Add option to select axes for which to calculate second moments.

### DIFF
--- a/cython_jam.pxd
+++ b/cython_jam.pxd
@@ -9,6 +9,14 @@ cdef extern from "../src/jam/jam.h":
         double *rxx, double *ryy, double *rzz, \
         double *rxy, double *rxz, double *ryz)
     
+    void jam_axi_rms_axes(double *xp, double *yp, int nxy, double incl, \
+        double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
+        double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
+        double *beta, int nrad, int nang, int* integrationFlag, \
+        double *rxx, double *ryy, double *rzz, \
+        double *rxy, double *rxz, double *ryz, \
+        int xaxis, int yaxis, int zaxis)
+    
     void jam_axi_vel(double *xp, double *yp, int nxy, double incl, \
         double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
         double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ from Cython.Build import cythonize
 
 sources = ["cjam/_jam_axi.pyx"]
 interp = ["src/interp/interp2dpol.c"]
-jam = ["src/jam/jam_axi_rms.c", "src/jam/jam_axi_rms_mgeint.c",
-    "src/jam/jam_axi_rms_mmt.c", "src/jam/jam_axi_rms_wmmt.c",
-    "src/jam/jam_axi_vel.c", "src/jam/jam_axi_vel_losint.c",
-    "src/jam/jam_axi_vel_mgeint.c", "src/jam/jam_axi_vel_mmt.c",
-    "src/jam/jam_axi_vel_wmmt.c"]
+jam = ["src/jam/jam_axi_rms.c", "src/jam/jam_axi_rms_axes.c",
+    "src/jam/jam_axi_rms_mgeint.c", "src/jam/jam_axi_rms_mmt.c",
+    "src/jam/jam_axi_rms_wmmt.c", "src/jam/jam_axi_vel.c",
+    "src/jam/jam_axi_vel_losint.c", "src/jam/jam_axi_vel_mgeint.c",
+    "src/jam/jam_axi_vel_mmt.c", "src/jam/jam_axi_vel_wmmt.c"]
 mge = ["src/mge/mge_addbh.c", "src/mge/mge_dens.c", "src/mge/mge_deproject.c",
     "src/mge/mge_qmed.c", "src/mge/mge_read.c", "src/mge/mge_surf.c"]
 tools = ["src/tools/maximum.c", "src/tools/median.c", "src/tools/minimum.c",

--- a/src/jam/jam.h
+++ b/src/jam/jam.h
@@ -70,6 +70,14 @@ void jam_axi_rms(double *xp, double *yp, int nxy, double incl, \
     double *rxx, double *ryy, double *rzz, \
     double *rxy, double *rxz, double *ryz);
 
+void jam_axi_rms_axes(double *xp, double *yp, int nxy, double incl, \
+    double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
+    double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
+    double *beta, int nrad, int nang, int* integrationFlag, \
+    double *rxx, double *ryy, double *rzz, \
+    double *rxy, double *rxz, double *ryz, \
+    int xaxis, int yaxis, int zaxis);
+
 double jam_axi_rms_mgeint( double, void * );
 
 double* jam_axi_rms_mmt( double *,double *, int, double, \

--- a/src/jam/jam_axi_rms.c
+++ b/src/jam/jam_axi_rms.c
@@ -38,62 +38,12 @@ double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
 double *beta, int nrad, int nang, int* integrationFlag, \
 double *rxx, double *ryy, double *rzz, double *rxy, double *rxz, double *ryz) {
     
-    struct multigaussexp lum, pot;
-    double* mu;
-    int i, check;
-    
-    // put luminous MGE components into structure
-    lum.area = lum_area;
-    lum.sigma = lum_sigma;
-    lum.q = lum_q;
-    lum.ntotal = lum_total;
-    
-    // put potential MGE components into structure
-    pot.area = pot_area;
-    pot.sigma = pot_sigma;
-    pot.q = pot_q;
-    pot.ntotal = pot_total;
-    
-    // calculate xx moments and put into results array
-    mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 1, \
-        integrationFlag);
-    for (i=0; i<nxy; i++) rxx[i] = mu[i];
-    
-    // check for any non-zero beta or non-unity flattening
-    check = 0;
-    for (i=0; i<lum.ntotal; i++) if (beta[i]!=0.) check++;
-    for (i=0; i<lum.ntotal; i++) if (lum_q[i]!=1.) check++;
-    for (i=0; i<pot.ntotal; i++) if (pot_q[i]!=1.) check++;
-    
-    // for anisotropic models, calculate the other moments
-    if (check>0) {
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
-            2, integrationFlag);
-        for (i=0; i<nxy; i++) ryy[i] = mu[i];
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
-            3, integrationFlag);
-        for (i=0; i<nxy; i++) rzz[i] = mu[i];
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
-            4, integrationFlag);
-        for (i=0; i<nxy; i++) rxy[i] = mu[i];
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
-            5, integrationFlag);
-        for (i=0; i<nxy; i++) rxz[i] = mu[i];
-        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
-            6, integrationFlag);
-        for (i=0; i<nxy; i++) ryz[i] = mu[i];
-    }
-    // otherwise just propagate
-    else {
-        for (i=0; i<nxy; i++) ryy[i] = mu[i];
-        for (i=0; i<nxy; i++) rzz[i] = mu[i];
-        for (i=0; i<nxy; i++) rxy[i] = 0.;
-        for (i=0; i<nxy; i++) rxz[i] = 0.;
-        for (i=0; i<nxy; i++) ryz[i] = 0.;
-    }
-    
-    // free memory
-    free(mu);
+    jam_axi_rms_axes(xp, yp, nxy, incl,
+        lum_area, lum_sigma, lum_q, lum_total,
+        pot_area, pot_sigma, pot_q, pot_total,
+        beta, nrad, nang, integrationFlag,
+        rxx, ryy, rzz, rxy, rxz, ryz,
+        1, 1, 1);
     
     return;
 }

--- a/src/jam/jam_axi_rms_axes.c
+++ b/src/jam/jam_axi_rms_axes.c
@@ -1,0 +1,122 @@
+/* ----------------------------------------------------------------------------
+  JAM_AXI_RMS_AXES
+    
+    Wrapper for second moment calculator designed to interface with Python, calculating only requested moments.
+    
+    INPUTS
+      xp : projected x' [pc]
+      yp : projected y' [pc]
+      nxy : number of x' and y' values given
+      incl : inclination [radians]
+      lum_area : projected luminous MGE area
+      lum_sigma : projected luminous MGE width
+      lum_q : projected luminous MGE flattening
+      pot_area : projected potential MGE area
+      pot_sigma : projected potential MGE sigma
+      pot_q : projected potential MGE flattening
+      beta : velocity anisotropy (1-vz^2/vr^2)
+      nrad : number of radial bins in interpolation grid
+      nang : number of angular bins in interpolation grid
+      rxx : array to hold the xx second moments calculated
+      ryy : array to hold the yy second moments calculated
+      rzz : array to hold the zz second moments calculated
+      rxy : array to hold the xy second moments calculated
+      rxz : array to hold the xz second moments calculated
+      ryz : array to hold the yz second moments calculated
+      xaxis : whether to calculate moments involving x
+      yaxis : whether to calculate moments involving y
+      zaxis : whether to calculate moments involving z
+---------------------------------------------------------------------------- */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "jam.h"
+#include "../mge/mge.h"
+
+
+void jam_axi_rms_axes(double *xp, double *yp, int nxy, double incl, \
+double *lum_area, double *lum_sigma, double *lum_q, int lum_total, \
+double *pot_area, double *pot_sigma, double *pot_q, int pot_total, \
+double *beta, int nrad, int nang, int* integrationFlag, \
+double *rxx, double *ryy, double *rzz, double *rxy, double *rxz, double *ryz,
+int xaxis, int yaxis, int zaxis) {
+    
+    struct multigaussexp lum, pot;
+    double* mu;
+    int i, check;
+    
+    // if there are no moments requested, exit immediately
+    if (!xaxis && !yaxis && !zaxis) {
+        return;
+    }
+    
+    // put luminous MGE components into structure
+    lum.area = lum_area;
+    lum.sigma = lum_sigma;
+    lum.q = lum_q;
+    lum.ntotal = lum_total;
+    
+    // put potential MGE components into structure
+    pot.area = pot_area;
+    pot.sigma = pot_sigma;
+    pot.q = pot_q;
+    pot.ntotal = pot_total;
+    
+    // check for any non-zero beta or non-unity flattening
+    check = 0;
+    for (i=0; i<lum.ntotal; i++) if (beta[i]!=0.) check++;
+    for (i=0; i<lum.ntotal; i++) if (lum_q[i]!=1.) check++;
+    for (i=0; i<pot.ntotal; i++) if (pot_q[i]!=1.) check++;
+    
+    // for anisotropic models, calculate each requested moment
+    if (check>0) {
+        if (xaxis) {
+            // calculate xx moments and put into results array
+            mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
+                1, integrationFlag);
+            for (i=0; i<nxy; i++) rxx[i] = mu[i];
+        }
+        if (yaxis) {
+            mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
+                2, integrationFlag);
+            for (i=0; i<nxy; i++) ryy[i] = mu[i];
+        }
+        if (zaxis) {
+            mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
+                3, integrationFlag);
+            for (i=0; i<nxy; i++) rzz[i] = mu[i];
+        }
+        if (xaxis && yaxis) {
+            mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
+                4, integrationFlag);
+            for (i=0; i<nxy; i++) rxy[i] = mu[i];
+        }
+        if (xaxis && zaxis) {
+            mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
+                5, integrationFlag);
+            for (i=0; i<nxy; i++) rxz[i] = mu[i];
+        }
+        if (yaxis && zaxis) {
+            mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, \
+                6, integrationFlag);
+            for (i=0; i<nxy; i++) ryz[i] = mu[i];
+        }
+    }
+    // otherwise just calculate one and propagate
+    else {
+        mu = jam_axi_rms_mmt(xp, yp, nxy, incl, &lum, &pot, beta, nrad, nang, 1, \
+            integrationFlag);
+        if (xaxis) for (i=0; i<nxy; i++) rxx[i] = mu[i];
+        if (yaxis) for (i=0; i<nxy; i++) ryy[i] = mu[i];
+        if (zaxis) for (i=0; i<nxy; i++) rzz[i] = mu[i];
+        if (xaxis && yaxis) for (i=0; i<nxy; i++) rxy[i] = 0.;
+        if (xaxis && zaxis) for (i=0; i<nxy; i++) rxz[i] = 0.;
+        if (yaxis && zaxis) for (i=0; i<nxy; i++) ryz[i] = 0.;
+    }
+    
+    // free memory
+    free(mu);
+    
+    return;
+}


### PR DESCRIPTION
CJAM always calculates all six second moments, but as I only have stellar line-of-sight velocities and no proper motions for my galaxies, I only need the moments along the z axis.  I have made some small modifications to CJAM such that one can select the axes that one is interested in, and in this way have sped up my calculations by a factor
of about 6.  I have made the changes in such a way that CJAM remains backwards compatible with its previous behaviour, both in C and in Python, though I have only tested the Python code.

With this patch, CJAM only returns the keys relevant to the selected axis.  For example, if only the z axis is selected, you will get vz and v2zz.  If instead you select x and y, you will get vx, vy, v2xx, v2yy, and v2xy.

All first moments are still calculated, but only the relevant ones are returned.  This is because calculating only the relevant first moments while keeping the code backwards compatible is not as straightforward as for the second moments.

I would be happy to make changes if there is something in here that you do not like.  If everything checks out, I will have a go at updating the documentation.